### PR TITLE
Enable wildcards in URI to match incoming request 

### DIFF
--- a/models/seo_title.php
+++ b/models/seo_title.php
@@ -48,7 +48,7 @@ class SeoTitle extends SeoAppModel {
 	function findTitleByUri($request = null){
 		return $this->find('first', array(
 			'conditions' => array(
-				"{$this->SeoUri->alias}.uri" => $request,
+				array("'$request' LIKE `{$this->SeoUri->alias}`.`uri`"),
 				"{$this->SeoUri->alias}.is_approved" => true
 			),
 			'contain' => array("{$this->SeoUri->alias}.uri"),


### PR DESCRIPTION
wildcard is %, so URIs with URI-encoded characters must be escaped using %%.
e.g. `/press/%/some%%20article` matches requests `/press/new/some%20article` and `/press/archived/some%20article`. Existing URIs with URI-encoded characters from the old scheme will still work as they are, but will also match weird URLs like `some_other20_article`. Suggest to update old URIs or add a toggle in the admin to allow wildcards, off by default.
